### PR TITLE
Specify NIC for Access IP

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -16,58 +16,58 @@
 		},
 		{
 			"ImportPath": "github.com/hashicorp/terraform/config",
-			"Comment": "v0.3.7-211-g751822b",
-			"Rev": "751822b53f9a3d08fed3983e7037008c5034f263"
+			"Comment": "v0.5.3-199-gf1a88fc",
+			"Rev": "f1a88fca5bdaabeda5ef12399da4599d75f11b5b"
 		},
 		{
 			"ImportPath": "github.com/hashicorp/terraform/dag",
-			"Comment": "v0.3.7-211-g751822b",
-			"Rev": "751822b53f9a3d08fed3983e7037008c5034f263"
+			"Comment": "v0.5.3-199-gf1a88fc",
+			"Rev": "f1a88fca5bdaabeda5ef12399da4599d75f11b5b"
 		},
 		{
 			"ImportPath": "github.com/hashicorp/terraform/flatmap",
-			"Comment": "v0.3.7-211-g751822b",
-			"Rev": "751822b53f9a3d08fed3983e7037008c5034f263"
+			"Comment": "v0.5.3-199-gf1a88fc",
+			"Rev": "f1a88fca5bdaabeda5ef12399da4599d75f11b5b"
 		},
 		{
 			"ImportPath": "github.com/hashicorp/terraform/helper/config",
-			"Comment": "v0.3.7-211-g751822b",
-			"Rev": "751822b53f9a3d08fed3983e7037008c5034f263"
+			"Comment": "v0.5.3-199-gf1a88fc",
+			"Rev": "f1a88fca5bdaabeda5ef12399da4599d75f11b5b"
 		},
 		{
 			"ImportPath": "github.com/hashicorp/terraform/helper/multierror",
-			"Comment": "v0.3.7-211-g751822b",
-			"Rev": "751822b53f9a3d08fed3983e7037008c5034f263"
+			"Comment": "v0.5.3-199-gf1a88fc",
+			"Rev": "f1a88fca5bdaabeda5ef12399da4599d75f11b5b"
 		},
 		{
 			"ImportPath": "github.com/hashicorp/terraform/helper/resource",
-			"Comment": "v0.3.7-211-g751822b",
-			"Rev": "751822b53f9a3d08fed3983e7037008c5034f263"
+			"Comment": "v0.5.3-199-gf1a88fc",
+			"Rev": "f1a88fca5bdaabeda5ef12399da4599d75f11b5b"
 		},
 		{
 			"ImportPath": "github.com/hashicorp/terraform/helper/schema",
-			"Comment": "v0.3.7-211-g751822b",
-			"Rev": "751822b53f9a3d08fed3983e7037008c5034f263"
+			"Comment": "v0.5.3-199-gf1a88fc",
+			"Rev": "f1a88fca5bdaabeda5ef12399da4599d75f11b5b"
 		},
 		{
 			"ImportPath": "github.com/hashicorp/terraform/helper/url",
-			"Comment": "v0.3.7-211-g751822b",
-			"Rev": "751822b53f9a3d08fed3983e7037008c5034f263"
+			"Comment": "v0.5.3-199-gf1a88fc",
+			"Rev": "f1a88fca5bdaabeda5ef12399da4599d75f11b5b"
 		},
 		{
 			"ImportPath": "github.com/hashicorp/terraform/plugin",
-			"Comment": "v0.3.7-211-g751822b",
-			"Rev": "751822b53f9a3d08fed3983e7037008c5034f263"
+			"Comment": "v0.5.3-199-gf1a88fc",
+			"Rev": "f1a88fca5bdaabeda5ef12399da4599d75f11b5b"
 		},
 		{
 			"ImportPath": "github.com/hashicorp/terraform/rpc",
-			"Comment": "v0.3.7-211-g751822b",
-			"Rev": "751822b53f9a3d08fed3983e7037008c5034f263"
+			"Comment": "v0.5.3-199-gf1a88fc",
+			"Rev": "f1a88fca5bdaabeda5ef12399da4599d75f11b5b"
 		},
 		{
 			"ImportPath": "github.com/hashicorp/terraform/terraform",
-			"Comment": "v0.3.7-211-g751822b",
-			"Rev": "751822b53f9a3d08fed3983e7037008c5034f263"
+			"Comment": "v0.5.3-199-gf1a88fc",
+			"Rev": "f1a88fca5bdaabeda5ef12399da4599d75f11b5b"
 		},
 		{
 			"ImportPath": "github.com/hashicorp/yamux",
@@ -91,7 +91,7 @@
 		},
 		{
 			"ImportPath": "gopkg.in/lxc/go-lxc.v2",
-			"Rev": "4c6cb39f385e62ce1f4d1042e159e332856204b7"
+			"Rev": "a0fa4019e64b385dfa2fb8abcabcdd2f66871639"
 		}
 	]
 }

--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ resource "lxc_container" "my_container" {
 * `options`: Optional. A set of key/value pairs of extra LXC options. See `lxc.container.conf(5)`.
 * `network_interface`: Optional. Defines a NIC.
   * `type`: Optional. The type of NIC. Defaults to `veth`.
+  * `management`: Optional. Make this NIC the management / accessible NIC.
   * `options`: Optional. A set of key/value `lxc.network.*` pairs for the NIC.
 
 #### Notes
@@ -240,6 +241,7 @@ resource "lxc_clone" "my_clone" {
 * `options`: Optional. A set of key/value pairs of extra LXC options. See `lxc.container.conf(5)`.
 * `network_interface`: Optional. Defines a NIC.
   * `type`: Optional. The type of NIC. Defaults to `veth`.
+  * `management`: Optional. Make this NIC the management / accessible NIC.
   * `options`: Optional. A set of key/value `lxc.network.*` pairs for the NIC.
 
 #### Exported Parameters

--- a/lxc/resource_lxc_clone.go
+++ b/lxc/resource_lxc_clone.go
@@ -56,6 +56,11 @@ func resourceLXCClone() *schema.Resource {
 							Optional: true,
 							Default:  "veth",
 						},
+						"management": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  false,
+						},
 						"options": &schema.Schema{
 							Type:     schema.TypeMap,
 							Optional: true,
@@ -158,25 +163,9 @@ func resourceLXCCloneRead(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	ipv4 := ""
-	ipv6 := ""
-	if ipv4s, err := c.IPv4Addresses(); err == nil {
-		for _, v := range ipv4s {
-			if ipv4 == "" {
-				ipv4 = v
-			}
-		}
+	if err = lxcIPAddressConfiguration(c, d); err != nil {
+		return err
 	}
-	if ipv6s, err := c.IPv6Addresses(); err == nil {
-		for _, v := range ipv6s {
-			if ipv6 == "" {
-				ipv6 = v
-			}
-		}
-	}
-
-	d.Set("address_v4", ipv4)
-	d.Set("address_v6", ipv6)
 
 	return nil
 }

--- a/lxc/resource_lxc_container.go
+++ b/lxc/resource_lxc_container.go
@@ -108,6 +108,11 @@ func resourceLXCContainer() *schema.Resource {
 							Optional: true,
 							Default:  "veth",
 						},
+						"management": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  false,
+						},
 						"options": &schema.Schema{
 							Type:     schema.TypeMap,
 							Optional: true,
@@ -220,30 +225,9 @@ func resourceLXCContainerRead(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	ipv4 := ""
-	ipv6 := ""
-	if ipv4s, err := c.IPv4Addresses(); err == nil {
-		for _, v := range ipv4s {
-			if ipv4 == "" {
-				ipv4 = v
-			}
-		}
+	if err = lxcIPAddressConfiguration(c, d); err != nil {
+		return err
 	}
-	if ipv6s, err := c.IPv6Addresses(); err == nil {
-		for _, v := range ipv6s {
-			if ipv6 == "" {
-				ipv6 = v
-			}
-		}
-	}
-
-	d.Set("address_v4", ipv4)
-	d.Set("address_v6", ipv6)
-
-	d.SetConnInfo(map[string]string{
-		"type": "ssh",
-		"host": ipv4,
-	})
 
 	return nil
 }


### PR DESCRIPTION
This commit adds the ability to tag a network interface as a management
interface. Terraform will then use the first IPv4 and IPv6 addresses found
on those interfaces for the access_ipv4 and access_ipv6 exported parameters.

Fixes #3 
