### PR TITLE
Few bugfixes and add a exec option to container

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -3,6 +3,10 @@
 	"GoVersion": "go1.4.2",
 	"Deps": [
 		{
+			"ImportPath": "github.com/google/shlex",
+			"Rev": "6f45313302b9c56850fc17f99e40caebce98c716"
+		},
+		{
 			"ImportPath": "github.com/hashicorp/errwrap",
 			"Rev": "7554cd9344cec97297fa6649b055a8c98c2a1e55"
 		},

--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ resource "lxc_container" "my_container" {
 
 * `name`: Required. The name of the container.
 * `backend`: Optional. The storage backend to use. Valid options are: btrfs, directory, lvm, zfs, aufs, overlayfs, loopback, or best. Defaults to `directory`.
+* `exec`: Optional. Commands to run after container creation. This won't be interpreted by a shell so use `bash -c "{shellcode}"` if you want a shell.
 * `template_name`: Optional. Defaults to `download`. See `/usr/share/lxc/templates` for more template options.
 * `template_distro`: Optional. Defaults to `ubuntu`.
 * `template_release`: Optional. Defaults to `trusty`.

--- a/lxc/resource_lxc_bridge.go
+++ b/lxc/resource_lxc_bridge.go
@@ -47,7 +47,7 @@ func resourceLXCBridgeCreate(d *schema.ResourceData, meta interface{}) error {
 			Name: d.Get("name").(string),
 		}}
 		if err := netlink.LinkAdd(bridge); err != nil {
-			return fmt.Errorf("Error creating bridge %s: %v", br, err
+			return fmt.Errorf("Error creating bridge %s: %v", br, err)
 		}
 
 		if ifaceName, ok := d.GetOk("hostInterface"); ok {

--- a/lxc/resource_lxc_bridge.go
+++ b/lxc/resource_lxc_bridge.go
@@ -20,11 +20,13 @@ func resourceLXCBridge() *schema.Resource {
 			"name": &schema.Schema{
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: true,
 			},
 
 			"hostInterface": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
+				ForceNew: true,
 			},
 
 			"mac": &schema.Schema{

--- a/lxc/resource_lxc_bridge.go
+++ b/lxc/resource_lxc_bridge.go
@@ -47,7 +47,7 @@ func resourceLXCBridgeCreate(d *schema.ResourceData, meta interface{}) error {
 			Name: d.Get("name").(string),
 		}}
 		if err := netlink.LinkAdd(bridge); err != nil {
-			return fmt.Errorf("Error creating bridge %s: %v", br, err)
+			return fmt.Errorf("Error creating bridge %s: %v", br, err
 		}
 
 		if ifaceName, ok := d.GetOk("hostInterface"); ok {
@@ -60,9 +60,9 @@ func resourceLXCBridgeCreate(d *schema.ResourceData, meta interface{}) error {
 				return fmt.Errorf("Error adding host interface %s to bridge %s : %v", ifaceName, br, err)
 			}
 		}
-		log.Printf("[INFO] Created new bridge %s", br)
+		log.Printf("[INFO] Created new bridge %s: %v", br, bridge)
 	} else {
-		log.Printf("[INFO] Found existing bridge %s", br)
+		log.Printf("[INFO] Found existing bridge %s: %v", br, bridge)
 	}
 
 	log.Printf("[INFO] Bringing bridge %s up", br)

--- a/lxc/resource_lxc_bridge.go
+++ b/lxc/resource_lxc_bridge.go
@@ -41,7 +41,8 @@ func resourceLXCBridgeCreate(d *schema.ResourceData, meta interface{}) error {
 	br := d.Get("name").(string)
 	var bridge netlink.Link
 
-	if bridge, err := netlink.LinkByName(br); err != nil {
+	bridge, err := netlink.LinkByName(br)
+	if err != nil {
 		bridge = &netlink.Bridge{netlink.LinkAttrs{
 			Name: d.Get("name").(string),
 		}}
@@ -59,14 +60,14 @@ func resourceLXCBridgeCreate(d *schema.ResourceData, meta interface{}) error {
 				return fmt.Errorf("Error adding host interface %s to bridge %s : %v", ifaceName, br, err)
 			}
 		}
-		log.Printf("[INFO] Created new bridge %s: %v", br, bridge)
+		log.Printf("[INFO] Created new bridge %s", br)
 	} else {
-		log.Printf("[INFO] Found existing bridge %s: %v", br, bridge)
+		log.Printf("[INFO] Found existing bridge %s", br)
 	}
 
-	log.Printf("[INFO] Bringing bridge up.")
+	log.Printf("[INFO] Bringing bridge %s up", br)
 	if err := netlink.LinkSetUp(bridge); err != nil {
-		return fmt.Errorf("Error bringing bridge up: %v", err)
+		return fmt.Errorf("Error bringing bridge %s up: %v", br, err)
 	}
 
 	d.SetId(strconv.Itoa(bridge.Attrs().Index))

--- a/lxc/resource_lxc_bridge_test.go
+++ b/lxc/resource_lxc_bridge_test.go
@@ -26,6 +26,17 @@ func TestLXCBridge(t *testing.T) {
 						"lxc_bridge.accept_test", "name", "accept_test"),
 				),
 			},
+			resource.TestStep{
+				Config: testAccLXCBridgeWithIface,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLXCBridgeExists(
+						t, "lxc_bridge.accept_test_iface", &bridge),
+					resource.TestCheckResourceAttr(
+						"lxc_bridge.accept_test_iface", "name", "accept_test_iface"),
+					resource.TestCheckResourceAttr(
+						"lxc_bridge.accept_test_iface", "hostInterface", "accept_test"),
+				),
+			},
 		},
 	})
 }
@@ -80,4 +91,10 @@ func testAccCheckLXCBridgeDestroy(s *terraform.State) error {
 var testAccLXCBridge = `
 	resource "lxc_bridge" "accept_test" {
 		name = "accept_test"
+	}`
+
+var testAccLXCBridgeWithIP = `
+	resource "lxc_bridge" "accept_test" {
+		name = "accept_test_ip"
+		hostInterface = "accept_test"
 	}`

--- a/lxc/resource_lxc_bridge_test.go
+++ b/lxc/resource_lxc_bridge_test.go
@@ -93,7 +93,7 @@ var testAccLXCBridge = `
 		name = "accept_test"
 	}`
 
-var testAccLXCBridgeWithIP = `
+var testAccLXCBridgeWithIface = `
 	resource "lxc_bridge" "accept_test" {
 		name = "accept_test_ip"
 		hostInterface = "accept_test"

--- a/lxc/resource_lxc_clone.go
+++ b/lxc/resource_lxc_clone.go
@@ -20,6 +20,7 @@ func resourceLXCClone() *schema.Resource {
 			"name": &schema.Schema{
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: true,
 			},
 			"backend": &schema.Schema{
 				Type:     schema.TypeString,
@@ -30,25 +31,30 @@ func resourceLXCClone() *schema.Resource {
 			"source": &schema.Schema{
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: true,
 			},
 			"keep_mac": &schema.Schema{
 				Type:     schema.TypeBool,
 				Optional: true,
 				Default:  false,
+				ForceNew: true,
 			},
 			"snapshot": &schema.Schema{
 				Type:     schema.TypeBool,
 				Optional: true,
 				Default:  false,
+				ForceNew: true,
 			},
 			"options": &schema.Schema{
 				Type:     schema.TypeMap,
 				Optional: true,
 				Default:  nil,
+				ForceNew: true,
 			},
 			"network_interface": &schema.Schema{
 				Type:     schema.TypeList,
 				Optional: true,
+				ForceNew: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"type": &schema.Schema{

--- a/lxc/resource_lxc_container.go
+++ b/lxc/resource_lxc_container.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/google/shlex"
 	"github.com/hashicorp/terraform/helper/schema"
 	"gopkg.in/lxc/go-lxc.v2"
 )
@@ -138,6 +139,12 @@ func resourceLXCContainer() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"exec": &schema.Schema{
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				ForceNew: true,
+			},
 		},
 	}
 }
@@ -216,6 +223,20 @@ func resourceLXCContainerCreate(d *schema.ResourceData, meta interface{}) error 
 
 	if err := lxcWaitForState(c, config.LXCPath, []string{"STOPPED", "STARTING"}, "RUNNING"); err != nil {
 		return err
+	}
+
+	if commands, defined := d.GetOk("exec"); defined {
+		if defined {
+			for _, command := range commands.([]interface{}) {
+				args, err := shlex.Split(command.(string))
+				if( err != nil ){
+					log.Printf("[ERROR] Error parsing arguments for command %d, skipping to next command",command.(string))
+				}else{
+					log.Printf("[INFO] Running command in container %s : %s\n", c.Name(), command.(string))
+					c.RunCommand(args,lxc.DefaultAttachOptions)
+				}
+			}
+		}
 	}
 
 	log.Printf("[INFO] Waiting container to startup networking...\n")

--- a/lxc/resource_lxc_container.go
+++ b/lxc/resource_lxc_container.go
@@ -20,6 +20,7 @@ func resourceLXCContainer() *schema.Resource {
 			"name": &schema.Schema{
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: true,
 			},
 			"backend": &schema.Schema{
 				Type:     schema.TypeString,
@@ -77,30 +78,36 @@ func resourceLXCContainer() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Default:  false,
+				ForceNew: true,
 			},
 			"template_force_cache": &schema.Schema{
 				Type:     schema.TypeBool,
 				Optional: true,
 				Default:  false,
+				ForceNew: true,
 			},
 			"template_disable_gpg_validation": &schema.Schema{
 				Type:     schema.TypeBool,
 				Optional: true,
 				Default:  false,
+				ForceNew: true,
 			},
 			"template_extra_args": &schema.Schema{
 				Type:     schema.TypeList,
 				Optional: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
+				ForceNew: true,
 			},
 			"options": &schema.Schema{
 				Type:     schema.TypeMap,
 				Optional: true,
 				Default:  nil,
+				ForceNew: true,
 			},
 			"network_interface": &schema.Schema{
 				Type:     schema.TypeList,
 				Optional: true,
+				ForceNew: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"type": &schema.Schema{


### PR DESCRIPTION
Add a "exec" parameter to resource_lxc_container to exec bootstrap commands via LXC go library.

This allow the use of community image that doesn't take a ssh-key paramerter and don't install ssh server, like the debian jessie default image

I'm using it that way : 

```
resource "lxc_container" "infra-01" {
        [...]
        exec = [
                "mkdir -p /root/.ssh",
                "bash -c \"echo '${file(\"${path.module}/infra.key.pub\")}' > /root/.ssh/authorized_keys\"",
                "apt-get update",
                "apt-get --yes -q install openssh-server"
        ]
}
```
